### PR TITLE
Fix/Word-Indexing

### DIFF
--- a/components/LiveEditor.tsx
+++ b/components/LiveEditor.tsx
@@ -1,25 +1,26 @@
 import { useEffect, useState } from "react";
 
 import { UseWordiablesContext } from "../context/wordiablesContext";
-import { parseText, searchForWordiables } from "../lib/editor";
+import { checkWordiableStatus, parseText } from "../lib/editor";
 import styles from "../styles/editor.module.scss";
 
 export default function LiveEditor ({ text }: { text: any }){
-	const { wordiables, setWordiables } = UseWordiablesContext();
+	const [ wordiables, setWordiables ] = useState<string[]>([]);
+	const { wordiablesContext, setWordiablesContext } = UseWordiablesContext();
 
 	useEffect(
 		() => {
 			if (text) {
 				text.split(" ").forEach((word: string) => {
-					const isWordiable: boolean = searchForWordiables(word);
-					if (isWordiable && !wordiables.includes(word)) {
-						setWordiables([ ...wordiables, word ]);
+					const isWordiable: boolean = checkWordiableStatus(word);
+					if (isWordiable && !wordiablesContext.includes(word)) {
+						setWordiablesContext([ ...wordiablesContext, word ]);
 					}
 				});
 			}
 		},
-		[ text, setWordiables, wordiables ]
+		[ text, wordiablesContext, setWordiablesContext ]
 	);
 
-	return <div className={styles.liveEditor}>{parseText(text, wordiables)}</div>;
+	return <div className={styles.liveEditor}>{parseText(text, wordiablesContext)}</div>;
 }

--- a/components/LiveEditor.tsx
+++ b/components/LiveEditor.tsx
@@ -5,17 +5,23 @@ import { checkWordiableStatus, parseText } from "../lib/editor";
 import styles from "../styles/editor.module.scss";
 
 export default function LiveEditor ({ text }: { text: any }){
-	const [ wordiables, setWordiables ] = useState<string[]>([]);
 	const { wordiablesContext, setWordiablesContext } = UseWordiablesContext();
 
 	useEffect(
 		() => {
 			if (text) {
+				const liveWordiables: string[] = [];
+
 				text.split(" ").forEach((word: string) => {
 					const isWordiable: boolean = checkWordiableStatus(word);
-					if (isWordiable && !wordiablesContext.includes(word)) {
-						setWordiablesContext([ ...wordiablesContext, word ]);
+
+					if (isWordiable && !liveWordiables.includes(word)) {
+						liveWordiables.push(word);
+					} else if (!isWordiable && liveWordiables.includes(word)) {
+						liveWordiables.splice(liveWordiables.indexOf(word), 1);
 					}
+
+					setWordiablesContext(liveWordiables);
 				});
 			}
 		},

--- a/context/wordiablesContext.tsx
+++ b/context/wordiablesContext.tsx
@@ -5,17 +5,21 @@ type WordiablesContextProviderProps = {
 };
 
 const WordiablesContext = createContext<{
-	wordiables: string[];
-	setWordiables: React.Dispatch<React.SetStateAction<string[]>>;
+	wordiablesContext: string[];
+	setWordiablesContext: React.Dispatch<React.SetStateAction<string[]>>;
 }>({
-	wordiables: [],
-	setWordiables: () => {}
+	wordiablesContext: [],
+	setWordiablesContext: () => {}
 });
 
 export const WordiablesWrapper = ({ children }: WordiablesContextProviderProps) => {
-	const [ wordiables, setWordiables ] = useState<string[]>([]);
+	const [ wordiablesContext, setWordiablesContext ] = useState<string[]>([]);
 
-	return <WordiablesContext.Provider value={{ wordiables, setWordiables }}>{children}</WordiablesContext.Provider>;
+	return (
+		<WordiablesContext.Provider value={{ wordiablesContext, setWordiablesContext }}>
+			{children}
+		</WordiablesContext.Provider>
+	);
 };
 
 export const UseWordiablesContext = () => {

--- a/lib/editor.tsx
+++ b/lib/editor.tsx
@@ -24,7 +24,7 @@ const convertStringToHTML = (words: string[], wordiables: string[]) => {
 	return elements;
 };
 
-export const searchForWordiables = (text: string): boolean => {
+export const checkWordiableStatus = (text: string): boolean => {
 	const isWordiable = searchForBackslashes(text);
 	if (isWordiable) {
 		return true;


### PR DESCRIPTION
# Word Indexing Fix

**Before,** the wordiables context state could not detect Wordiables order changes or deleted Wordiables. 
**Now,** the wordiables and all matching iterations of the word will change colors automatically when Wordiable placement changes


## Checklist 

- Resolves #10 
- Update context variables names for clarity


